### PR TITLE
Optional paramenter IPV6, retrieval from different provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Setup on OpenWRT
 2. Move script to `/usr/bin/dyn-hover.sh`
 3. Setup a scheduled task as
 ```
-*/5 * * * * /usr/bin/dyn-hover.sh USERNAME PASSWORD DNSID
+*/5 * * * * /usr/bin/dyn-hover.sh USERNAME PASSWORD DNSID V4
 ```
 
 This will update your DNS record every 5 min to reflect the current external IP.

--- a/dyn-hover.sh
+++ b/dyn-hover.sh
@@ -1,18 +1,26 @@
 #!/bin/bash
 
-[[ $# -lt 3 ]] && echo "Usage: $0 USERNAME PASSWORD DNS_ID" && exit 1
+[[ $# -lt 3 ]] && echo "Usage: $0 USERNAME PASSWORD DNS_ID V4/V6(IP version, optional)" && exit 1
 
 COOKIEJAR=/tmp/hover_cookie.txt
 USERNAME=${1}
 PASSWORD=${2}
 DNS_ID=${3}
+IP_VERSION=${4:-"V4"}
+
+echo $IP_VERSION
+if [ $IP_VERSION == "V6" ]; then
+	IP=$(curl "http://v6.ipv6-test.com/api/myip.php" -ks)
+else
+	IP=$(curl "https://api.ipify.org" -ks)
+fi
+# echo "IP: ${IP}"
 
 # find your DNS ID here: https://www.hover.com/api/domains/yourdomain.com/dns/
 
 # (replace "yourdomain.com" with your actual domain, and look for the record
 # you want to change. The ID looks like: dns1234567)
 
-IP=$(curl "https://api.ipify.org" -ks)
 curl -k "https://www.hover.com/api/login" -X POST -G -d "username=${USERNAME}" -d "password=${PASSWORD}" -s -o /dev/null -c $COOKIEJAR
 curl -k "https://www.hover.com/api/dns/${DNS_ID}" -X PUT -d "content=${IP}" -s -b $COOKIEJAR
 echo


### PR DESCRIPTION
Two changes:

1. Additional parameter for IP version with default so that existing scripts will not break
2. Retrieval from `http://v6.ipv6-test.com/api/myip.php` for IPV6 addresses since ipfy does not suport IPv6 as discussed here: https://github.com/rdegges/ipify-api/issues/3

Another alternative would be this: `curl -6 https://myexternalip.com/raw`